### PR TITLE
fix 403 forbidden reponse

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -150,7 +150,7 @@ def retrieve_listing_data(url, properties):
     return None
 
 def get_max_page(listings_url):
-    page = requests.get(listings_url)
+    page = requests.get(listings_url, headers={'User-Agent': 'Mozilla/5.0'})
     soup = BeautifulSoup(page.content, "html.parser")
 
     pages_soup = soup.find("nav", attrs={"data-cy" : "pagination", "role" : "navigation"})


### PR DESCRIPTION
I was getting 403 response on request to otodom url. Probably should be also fixed for other request calls but didn't look into that

Before:
![image](https://github.com/user-attachments/assets/1cdc95a5-c67d-4f96-887f-1863f1ba5038)

After:
![image](https://github.com/user-attachments/assets/e526269c-e95c-4ae6-84bf-e96c9a6bc4a2)
